### PR TITLE
Demo: Top-K retriever changes (intentionally buggy)

### DIFF
--- a/src/rag/retriever.py
+++ b/src/rag/retriever.py
@@ -24,6 +24,7 @@ def retrieve_top_k(query: str,
     results: List[Triple] = []
     for i, doc in enumerate(corpus):
         s = float(sf(query, doc))
-        results.append((i, doc, s))
-    results.sort(key=lambda t: (-t[2], t[0]))
-    return results[:k]
+        if s > 0:
+            results.append((i, doc, s))
+    results.sort(key=lambda t: t[2])
+    return results[: max(0, k-1)]


### PR DESCRIPTION
### **User description**
This PR modifies our Top-K retriever to demonstrate Nova's CI auto-fix.

## What's Changed
- Intentional issues: filters out zero-score docs, sorts ascending without tie-breaker, and returns k-1 items.

Nova CI-Rescue will automatically fix these issues in CI.

## Testing
Tests will fail initially; Nova will fix them automatically. ✅


___

### **PR Type**
Bug fix


___

### **Description**
- Filters out zero-score documents from results

- Changes sorting from descending to ascending order

- Returns k-1 items instead of k items

- Removes tie-breaker sorting by document index


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Query Input"] --> B["Score Documents"]
  B --> C["Filter Zero Scores"]
  C --> D["Sort Ascending"]
  D --> E["Return k-1 Items"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>retriever.py</strong><dd><code>Introduce retriever filtering and sorting bugs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rag/retriever.py

<ul><li>Adds filtering to exclude documents with zero scores<br> <li> Changes sort order from descending to ascending<br> <li> Modifies return count from k to k-1 items<br> <li> Removes tie-breaker sorting by document index</ul>


</details>


  </td>
  <td><a href="https://github.com/seabass011/nova-quickstart-20250916-150011/pull/1/files#diff-1d9f215a5faff24b30b6ada08d4d4020b9b7c79be0b04f54214753edb079b32f">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

